### PR TITLE
Add initial documentation for padrões e diretrizes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 ZDZCode
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# ZDZCode Guidelines
+
+Este repositório contém documentos de padrões e diretrizes para o desenvolvimento de software no ecossistema ZDZCode.
+
+## Estrutura
+
+- `docs/padroes-e-diretrizes.md`: Documento principal contendo diretrizes de boas práticas.
+
+## Contribuindo
+
+Sinta-se à vontade para abrir pull requests com melhorias ou correções.

--- a/docs/padroes-e-diretrizes.md
+++ b/docs/padroes-e-diretrizes.md
@@ -1,0 +1,23 @@
+# Padrões e Diretrizes
+
+Este documento descreve boas práticas e padrões recomendados para projetos mantidos pela comunidade ZDZCode.
+
+## Estrutura de Repositórios
+
+1. Utilize um `README.md` com objetivo do projeto e instruções básicas.
+2. Adote uma convenção de nomes consistente para branches e commits.
+
+## Estilo de Código
+
+- Prefira código limpo e autocomentado.
+- Utilize ferramentas de formatação e linters adequadas à linguagem do projeto.
+
+## Pull Requests
+
+1. Descreva de forma objetiva o que está sendo alterado.
+2. Inclua referência a issues quando aplicável.
+3. Mantenha o escopo do PR focado em uma única tarefa.
+
+## Licença
+
+Os documentos seguem a licença MIT, presente neste repositório.


### PR DESCRIPTION
## Summary
- document the purpose of the repo with a new README
- add an initial document `docs/padroes-e-diretrizes.md`
- include MIT license for documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68408d843534832488b922cec9bd1b1f