### PR TITLE
Add more sections to guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ Este repositório contém documentos de padrões e diretrizes para o desenvolvim
 ## Contribuindo
 
 Sinta-se à vontade para abrir pull requests com melhorias ou correções.
+
+As diretrizes cobrem estrutura de repositórios, estilo de código, processo de pull requests, convenções de branches e commits, documentação e integração contínua.

--- a/docs/padroes-e-diretrizes.md
+++ b/docs/padroes-e-diretrizes.md
@@ -21,3 +21,30 @@ Este documento descreve boas práticas e padrões recomendados para projetos man
 ## Licença
 
 Os documentos seguem a licença MIT, presente neste repositório.
+
+## Branches
+
+- Mantenha uma branch principal chamada `main`.
+- Crie branches de funcionalidade com o prefixo `feature/`.
+- Para correções de bugs utilize o prefixo `bugfix/`.
+
+## Commits
+
+- Escreva mensagens curtas e objetivas.
+- Utilize o tempo verbal no imperativo (ex: "Adiciona nova função").
+- Agrupe alterações relacionadas em um único commit sempre que possível.
+
+## Issues
+
+- Abra issues descrevendo claramente o problema ou proposta.
+- Quando possível, associe pull requests às issues correspondentes.
+
+## Documentação
+
+- Todo projeto deve possuir um `README.md` detalhado.
+- Utilize a pasta `docs/` para guias adicionais e referências.
+
+## Integração Contínua
+
+- Configure pipelines de CI para validar testes e qualidade de código.
+- Automatize verificações de lint e formatação.


### PR DESCRIPTION
## Summary
- expand guidelines document with sections about branches, commits, issues, docs and CI
- update README with description of covered topics

## Testing
- `echo 'No tests specified'`


------
https://chatgpt.com/codex/tasks/task_e_68408eb7aecc8324b3ff98298589a70e