### PR TITLE
Adicionar seções de diretrizes

### DIFF
--- a/docs/padroes-e-diretrizes.md
+++ b/docs/padroes-e-diretrizes.md
@@ -18,6 +18,32 @@ Este documento descreve boas práticas e padrões recomendados para projetos man
 2. Inclua referência a issues quando aplicável.
 3. Mantenha o escopo do PR focado em uma única tarefa.
 
+## Gerenciamento de Dependências
+
+- Utilize arquivos de bloqueio (lockfiles) sempre que a linguagem oferecer
+  suporte. Isso garante reprodutibilidade de builds.
+- Mantenha as dependências atualizadas e remova pacotes não utilizados.
+
+## Testes Automatizados
+
+- Crie testes unitários e de integração sempre que possível.
+- Automatize a execução dos testes em pipelines de CI.
+
+## Integração Contínua (CI/CD)
+
+- Configure pipelines para lint, testes e builds.
+- Aplique deploy automático apenas em branches estáveis.
+
+## Versionamento Semântico
+
+- Siga as recomendações do [SemVer](https://semver.org/lang/pt-BR/).
+- Registre as mudanças relevantes em um arquivo `CHANGELOG.md`.
+
+## Documentação
+
+- Documente a API e funcionalidades principais do projeto.
+- Mantenha exemplos de uso atualizados.
+
 ## Licença
 
 Os documentos seguem a licença MIT, presente neste repositório.


### PR DESCRIPTION
## Summary
- expandir `docs/padroes-e-diretrizes.md` com novas orientações sobre dependências, testes, CI/CD, versionamento e documentação
- manter a seção de licença no final do documento

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68408ebccc408324abd86507f3a1fd9d