### PR TITLE
Add service variable naming guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Este repositório contém documentos de padrões e diretrizes para o desenvolvim
 - `docs/padroes-e-diretrizes.md`: Documento principal contendo diretrizes de boas práticas.
 - `docs/guia-de-commits.md`: Regras para mensagens de commit e nomenclatura de branches.
 - `docs/orientacoes-desenvolvedores.md`: Guia de trabalho para desenvolvedores com exemplos de projetos.
+- `docs/nomenclatura-variaveis-servico.md`: Orientações para nomear variáveis nas classes de serviço.
 
 ## Contribuindo
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Documentos de Padrões e Diretrizes
+
+Este diretório contém documentos para orientar projetos do ecossistema **ZDZCode**.
+
+- [Padrões e Diretrizes](./padroes-e-diretrizes.md): recomendações gerais de estrutura, estilo e processos de contribuição.
+- [Guia de Commits](./guia-de-commits.md): regras para mensagens de commit e nomenclatura de branches.
+- [Guia de Trabalho para Desenvolvedores](./orientacoes-desenvolvedores.md): orientações de fluxo e exemplos de projetos.
+- [Nomenclatura de Variáveis em Serviços](./nomenclatura-variaveis-servico.md): padrões para nomear variáveis em classes de serviço.

--- a/docs/guia-de-commits.md
+++ b/docs/guia-de-commits.md
@@ -1,0 +1,29 @@
+# Guia de Commits e Branches
+
+Este documento define as convenções de commits e branches utilizadas nos projetos ZDZCode.
+
+## Mensagens de Commit
+
+- Utilize frases curtas e objetivas no imperativo.
+- Evite mensagens genéricas como "update" ou "fix".
+- Quando pertinente, referencie o código da issue.
+
+Exemplo:
+
+```
+feat: adicionar validacao de CPF
+```
+
+## Estratégia de Branches
+
+1. `main` deve refletir o código estável e pronto para produção.
+2. `develop` (quando existente) agrega funcionalidades que serão lançadas.
+3. Crie branches descritivas para cada tarefa:
+   - `feature/nome-breve`
+   - `bugfix/nome-breve`
+
+## Tags e Releases
+
+- Utilize [Semantic Versioning](https://semver.org/lang/pt-BR/) para numerar releases.
+- Marque versões estáveis com tags correspondentes.
+

--- a/docs/nomenclatura-variaveis-servico.md
+++ b/docs/nomenclatura-variaveis-servico.md
@@ -1,0 +1,41 @@
+# Nomenclatura de Variáveis em Classes de Serviço
+
+Este guia define padrões para nomear variáveis dentro de classes de serviço nos projetos **ZDZCode**. O objetivo é manter consistência e facilitar a compreensão do código por toda a equipe.
+
+## Regras Gerais
+
+1. Utilize **camelCase** para variáveis locais e parâmetros.
+2. Use **PascalCase** apenas para propriedades públicas.
+3. Evite abreviações que não sejam amplamente conhecidas.
+4. Prefira nomes descritivos que expressem claramente o propósito da variável.
+
+## Exemplos
+
+```csharp
+public class PedidoService
+{
+    private readonly IRepositorioPedidos _repositorioPedidos; // Campo privado
+
+    public PedidoService(IRepositorioPedidos repositorioPedidos)
+    {
+        _repositorioPedidos = repositorioPedidos;
+    }
+
+    public async Task<Pedido> CriarPedidoAsync(PedidoDto pedidoDto)
+    {
+        // Variáveis locais em camelCase
+        var novoPedido = new Pedido();
+        var dataCriacao = DateTime.UtcNow;
+        // ...
+        return await _repositorioPedidos.AdicionarAsync(novoPedido);
+    }
+}
+```
+
+## Boas Práticas
+
+- Prefixe variáveis booleanas com verbos como `is`, `has` ou `should`.
+- Para coleções, utilize nomes no plural: `pedidos`, `itens`.
+- Mantenha siglas com a primeira letra maiúscula e o restante em minúsculas, por exemplo: `idPedido`.
+
+Seguir estas convenções ajuda a evitar ambiguidades e melhora a legibilidade das classes de serviço.

--- a/docs/orientacoes-desenvolvedores.md
+++ b/docs/orientacoes-desenvolvedores.md
@@ -1,0 +1,37 @@
+# Guia de Trabalho para Desenvolvedores ZDZCode
+
+Este documento reúne orientações básicas para trabalhar nos projetos do ecossistema **ZDZCode**. Utilize-o em conjunto com o [Padrões e Diretrizes](padroes-e-diretrizes.md) e o [Guia de Commits](guia-de-commits.md).
+
+## Projetos de Exemplo
+
+Os repositórios de exemplo, localizados na pasta `exemplos`, podem ser utilizados como referência inicial. Eles incluem:
+
+- **ZDZCode.Data.EntityFramework**: Biblioteca para acesso a dados.
+- **ZDZCode.OMS.Linx**: Implementação da API da Linx.
+- **ZDZCode.Payments.Marvin**: Implementação da API da Marvin.
+- **ZDZCode.ProjectManagement.AzureDevops**: Integração com Azure DevOps.
+- **ZDZCode.Tests.Core**: Utilitário para testes.
+- **OMS.Domain**: Domínio do projeto OMS.
+- **OMS.API**: API principal do projeto OMS.
+- **ZDZCode.NuxtKit**: Componentes compartilhados de frontend.
+- **OMS.WEB**: Frontend da OMS.
+
+## Fluxo de Trabalho
+
+1. **Criação de Branch**  
+   Siga as convenções descritas em [Guia de Commits](guia-de-commits.md). Utilize prefixos como `feature/` ou `bugfix/`.
+2. **Desenvolvimento**  
+   - Para projetos .NET, mantenha a estrutura `src/Domain`, `Application`, `Infrastructure` e `API`.
+   - Para projetos frontend, utilize Vue 3 + Nuxt 3 e siga as práticas de lint e formatação com ESLint e Prettier.
+3. **Commits**  
+   Escreva mensagens curtas no imperativo, limitando a primeira linha a 72 caracteres. Consulte o [Guia de Commits](guia-de-commits.md) para exemplos.
+4. **Pull Requests**  
+   Mantenha um escopo focado e descreva claramente o que está sendo alterado. Sempre solicite revisão de pelo menos uma pessoa.
+5. **Integração Contínua**  
+   Configure pipelines no Azure DevOps para executar testes e validar qualidade de código.
+
+## Documentação
+
+- Mantenha um `README.md` em cada projeto explicando objetivo e passos de uso.
+- Utilize a pasta `docs/` para manuais adicionais e exemplos.
+- Atualize este repositório com novas diretrizes sempre que a stack ou os processos mudarem.

--- a/docs/padroes-e-diretrizes.md
+++ b/docs/padroes-e-diretrizes.md
@@ -1,0 +1,90 @@
+# Padrões e Diretrizes
+
+Este documento descreve boas práticas e padrões recomendados para projetos mantidos pela comunidade ZDZCode.
+
+Para convenções de commits e branches, consulte o documento [Guia de Commits](guia-de-commits.md).
+
+## Estrutura de Repositórios
+
+1. Utilize um `README.md` com objetivo do projeto e instruções básicas.
+2. Adote uma convenção de nomes consistente para branches e commits.
+3. Mantenha arquivos de configuracao e scripts de automacao em pastas dedicadas.
+
+## Convencoes de Branches
+
+- Use o formato `<tipo>/<descricao-curta>` ao criar branches.
+  - `feature/` para novas funcionalidades.
+  - `fix/` para correcoes de bugs.
+  - `chore/` para tarefas de manutencao.
+## Estilo de Código
+
+- Prefira código limpo e autocomentado.
+- Utilize ferramentas de formatação e linters adequadas à linguagem do projeto.
+## Mensagens de Commit
+
+1. Escreva mensagens no imperativo, em portugues.
+2. Limite a primeira linha a 72 caracteres.
+3. Use paragrafos adicionais para detalhes quando necessario.
+
+## Commits
+
+- Escreva mensagens de commit claras e objetivas.
+- Utilize o tempo verbal no imperativo ("Adiciona recurso X").
+
+## Branches
+
+- Padronize nomes de branches com o prefixo `feature/`, `fix/` ou `docs/`.
+- Evite nomes longos ou genéricos.
+
+## Revisão de Código
+
+1. Solicite revisão de pelo menos uma pessoa.
+2. Comente trechos de código que mereçam atenção especial.
+
+## Pull Requests
+
+1. Descreva de forma objetiva o que está sendo alterado.
+2. Inclua referência a issues quando aplicável.
+3. Mantenha o escopo do PR focado em uma única tarefa.
+
+## Revisao de Codigo
+
+- Todo PR deve ser revisado por pelo menos uma pessoa.
+- Utilize comentarios construtivos e objetivos.
+- Aprove mudancas somente apos garantir que testes automatizados estejam passando.
+
+## Issues
+
+- Registre bugs e sugestoes por meio de issues.
+- Descreva passos para reproduzir problemas ou resultados esperados.
+- Utilize labels para organizar prioridades.
+## Licença
+
+Os documentos seguem a licença MIT, presente neste repositório.
+
+## Branches
+
+- Mantenha uma branch principal chamada `main`.
+- Crie branches de funcionalidade com o prefixo `feature/`.
+- Para correções de bugs utilize o prefixo `bugfix/`.
+
+## Commits
+
+- Escreva mensagens curtas e objetivas.
+- Utilize o tempo verbal no imperativo (ex: "Adiciona nova função").
+- Agrupe alterações relacionadas em um único commit sempre que possível.
+
+## Issues
+
+- Abra issues descrevendo claramente o problema ou proposta.
+- Quando possível, associe pull requests às issues correspondentes.
+
+## Documentação
+
+- Todo projeto deve possuir um `README.md` detalhado.
+- Utilize a pasta `docs/` para guias adicionais e referências.
+
+## Integração Contínua
+
+- Configure pipelines de CI para validar testes e qualidade de código.
+- Automatize verificações de lint e formatação.


### PR DESCRIPTION
## Summary
- restore docs folder with guidelines
- document naming conventions for service class variables
- update root README links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841fcd0f280832483938febd4bf3ec0