### PR TITLE
docs: complementa instrucoes sobre entidades

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,5 +6,5 @@ Este diretório contém documentos para orientar projetos do ecossistema **ZDZCo
 - [Guia de Commits](./guia-de-commits.md): regras para mensagens de commit e nomenclatura de branches.
 - [Guia de Trabalho para Desenvolvedores](./orientacoes-desenvolvedores.md): orientações de fluxo e exemplos de projetos.
 - [Nomenclatura de Variáveis em Serviços](./nomenclatura-variaveis-servico.md): padrões para nomear variáveis em classes de serviço.
-- [Guia de Entidades](./guia-entidades.md): como criar classes de entidade compatíveis com o ZDZCode.Data.EntityFramework.
+- [Guia de Entidades](./guia-entidades.md): passo a passo para criar e mapear entidades compatíveis com o ZDZCode.Data.EntityFramework.
 - [Nomenclatura de Propriedades em Entidades](./nomenclatura-propriedades-entidade.md): guia para nomear propriedades em classes de entidade.

--- a/docs/guia-entidades.md
+++ b/docs/guia-entidades.md
@@ -71,11 +71,49 @@ public class PedidoConfiguration : IEntityTypeConfiguration<Pedido>
 
 Registre as configurações no `DbContext` do projeto que consome `ZDZCode.Data.EntityFramework`.
 
+### Registro no `DbContext`
+
+No contexto de dados principal, aplique todas as configurações utilizando o método `ApplyConfigurationsFromAssembly`:
+
+```csharp
+public class AppDbContext : DbContext
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+    }
+}
+```
+
 ## Boas Práticas
 
 - Evite colocar lógica de negócio complexa dentro das entidades; utilize serviços ou agregados.
 - Mantenha as entidades focadas em representar o estado do domínio.
 - Use propriedades `private set` ou métodos para controlar alterações quando necessário.
+
+## Exemplo Completo
+
+```csharp
+public class Pedido : BaseEntity
+{
+    public DateTime CriadoEm { get; private set; }
+    public DateTime? AtualizadoEm { get; private set; }
+    public StatusPedido Status { get; private set; }
+    public ICollection<ItemPedido> Itens { get; private set; } = new List<ItemPedido>();
+}
+
+public class PedidoConfiguration : IEntityTypeConfiguration<Pedido>
+{
+    public void Configure(EntityTypeBuilder<Pedido> builder)
+    {
+        builder.ToTable("Pedidos");
+        builder.HasKey(p => p.Id);
+        builder.Property(p => p.CriadoEm).IsRequired();
+        builder.Property(p => p.AtualizadoEm);
+        builder.HasMany(p => p.Itens).WithOne().HasForeignKey("PedidoId");
+    }
+}
+```
 
 Seguindo estas recomendações suas entidades continuarão compatíveis com a biblioteca de acesso a dados da ZDZCode e padronizadas com o restante dos projetos.
 

--- a/docs/nomenclatura-propriedades-entidade.md
+++ b/docs/nomenclatura-propriedades-entidade.md
@@ -2,6 +2,8 @@
 
 Este guia detalha como nomear propriedades em classes de entidade para manter a consistência dos projetos **ZDZCode** e garantir total compatibilidade com a biblioteca `ZDZCode.Data.EntityFramework`.
 
+Consulte o [Guia de Entidades](./guia-entidades.md) para um passo a passo completo de criação e mapeamento.
+
 ## Regras Básicas
 
 1. Utilize **PascalCase** em todas as propriedades públicas.


### PR DESCRIPTION
## Summary
- adiciona orientacoes de registro de configuracoes no DbContext
- inclui exemplo completo de entidade e configuracao
- referencia guia de entidades em nomenclatura de propriedades
- ajusta listagem de guia no README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842013a62bc83249025745d43cd4659